### PR TITLE
 - fixed bug that loads same data and appends it to existing list whe…

### DIFF
--- a/FinalappExample/app/src/main/java/com/tetraandroid/finalappexample/topmovies/TopMoviesActivity.java
+++ b/FinalappExample/app/src/main/java/com/tetraandroid/finalappexample/topmovies/TopMoviesActivity.java
@@ -12,9 +12,10 @@ import android.view.ViewGroup;
 import com.tetraandroid.finalappexample.root.App;
 import com.tetraandroid.retrofitexample.R;
 
-import javax.inject.Inject;
 import java.util.ArrayList;
 import java.util.List;
+
+import javax.inject.Inject;
 
 import butterknife.BindView;
 import butterknife.ButterKnife;
@@ -52,11 +53,6 @@ public class TopMoviesActivity extends AppCompatActivity implements TopMoviesAct
         recyclerView.setHasFixedSize(true);
         recyclerView.setLayoutManager(new LinearLayoutManager(this));
 
-    }
-
-    @Override
-    public void onResume() {
-        super.onResume();
         presenter.setView(this);
         presenter.loadData();
 


### PR DESCRIPTION
Moved the load data to the **onCreate** method because it was causing the app to miss behave in **onResume**. Pausing or Stopping the app would cause the **loadData** to append data to existing list, replicating its entries. 

I guess this should be handled on another layer since we would prefer to call **onLoad** in the **onResume** rather than **onCreate** but consider this change as a quick fix to make the app function as intended.